### PR TITLE
fix: guard against empty choices and message=None in LLM responses

### DIFF
--- a/evaluate/evaluate_by_scoring.py
+++ b/evaluate/evaluate_by_scoring.py
@@ -23,6 +23,8 @@ def llm_model_func(prompt, system_prompt=None, history_messages=[], **kwargs) ->
     response = openai_client.chat.completions.create(
         model=LLM_MODEL, messages=messages, **kwargs
     )
+    if not response.choices or response.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     return response.choices[0].message.content
 
 

--- a/evaluate/evaluate_by_selection.py
+++ b/evaluate/evaluate_by_selection.py
@@ -23,6 +23,8 @@ def llm_model_func(prompt, system_prompt=None, history_messages=[], **kwargs) ->
     response = openai_client.chat.completions.create(
         model=LLM_MODEL, messages=messages, **kwargs
     )
+    if not response.choices or response.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     return response.choices[0].message.content
 
 

--- a/reproduce/Step_2_extract_question.py
+++ b/reproduce/Step_2_extract_question.py
@@ -28,6 +28,8 @@ def llm_model_func(prompt, system_prompt=None, history_messages=[], **kwargs) ->
     response = openai_client.chat.completions.create(
         model=LLM_MODEL, messages=messages, **kwargs
     )
+    if not response.choices or response.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     return response.choices[0].message.content
 
 


### PR DESCRIPTION
## Problem

OpenAI-compatible APIs can fail in two ways that crash the evaluation pipeline:

1. **Empty choices list** (`IndexError`): `response.choices` is `[]` when the API returns no completions
2. **`message=None`** (`AttributeError`): `response.choices[0].message` is `None` when content is filtered (e.g., Gemini returns HTTP 200 with `PROHIBITED_CONTENT`, `message=None`)

## Affected files

- `evaluate/evaluate_by_scoring.py` — 1 site
- `evaluate/evaluate_by_selection.py` — 1 site
- `reproduce/Step_2_extract_question.py` — 1 site

**3 total sites guarded. 6 lines added, 0 deleted.**

## Fix pattern

```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```

## Verification

Detected by [pact](https://github.com/qizwiz/pact) static analysis. Confirmed live: Gemini 2.5 Flash returns HTTP 200 with `choices[0].message=None` on prohibited content.